### PR TITLE
fixed undefined symbol error with new gcc

### DIFF
--- a/src/bit-crusher.c
+++ b/src/bit-crusher.c
@@ -21,30 +21,30 @@ void bit_crusher_init_state(Bit_crusher_state *state)
 	state->last_sample = 0.0f;
 }
 
-inline float bit_crusher_limiter(const float val) {
+float bit_crusher_limiter(const float val) {
 	if (val > 1.0f) return 1.0f;
 	else if (val < -1.0f) return -1.0f;
 	else return val;
 }
 
-inline float bit_crusher_drive(const float val, const float drive)
+float bit_crusher_drive(const float val, const float drive)
 {
 	return bit_crusher_limiter( val * DB_CO(drive) );
 }
 
-inline BIT_CRUSHER_MAX_BIT_TYPE bit_crusher_to_N_bit(const float val, const uint8_t bit_depth)
+BIT_CRUSHER_MAX_BIT_TYPE bit_crusher_to_N_bit(const float val, const uint8_t bit_depth)
 {
 	if (val >= 1.0) return powf(2, bit_depth-1) - 1;
 	else if (val <= -1.0) return powf(-2, bit_depth-1);
 	else return floorf( val * -powf(-2, bit_depth-1) );
 }
 
-inline float bit_crusher_N_bit_to_float(const BIT_CRUSHER_MAX_BIT_TYPE val, const uint8_t bit_depth)
+float bit_crusher_N_bit_to_float(const BIT_CRUSHER_MAX_BIT_TYPE val, const uint8_t bit_depth)
 {
 	return val / -powf(-2, bit_depth-1);
 }
 
-inline float bit_crusher_crush_bit(const float val, const uint8_t bit_depth)
+float bit_crusher_crush_bit(const float val, const uint8_t bit_depth)
 {
 	return bit_crusher_N_bit_to_float(
 		bit_crusher_to_N_bit(val, bit_depth),

--- a/src/ladspa.c
+++ b/src/ladspa.c
@@ -200,6 +200,7 @@ const LADSPA_Descriptor* ladspa_descriptor(unsigned long Index)
 			descriptor_stereo->Label = strdup("bit_crusher_stereo");
 			descriptor_stereo->Name = strdup("Bit Crusher (Stereo)");
 			descriptor_stereo->Maker = strdup("Viacheslav Lotsmanov (unclechu)");
+			descriptor_stereo->Copyright = strdup("Viacheslav Lotsmanov (unclechu)");
 
 			descriptor_stereo->PortCount = 10;
 

--- a/src/ladspa.c
+++ b/src/ladspa.c
@@ -120,6 +120,7 @@ const LADSPA_Descriptor* ladspa_descriptor(unsigned long Index)
 			descriptor_mono->Label = strdup("bit_crusher_mono");
 			descriptor_mono->Name = strdup("Bit Crusher (Mono)");
 			descriptor_mono->Maker = strdup("Viacheslav Lotsmanov");
+			descriptor_mono->Copyright = strdup("Viacheslav Lotsmanov");
 
 			descriptor_mono->PortCount = 8;
 

--- a/src/run_helpers.h
+++ b/src/run_helpers.h
@@ -8,42 +8,42 @@ Author: Viacheslav Lotsmanov
 
 */
 
-inline float prepare_drive_knob(KNOB_VAL_TYPE val)
+float prepare_drive_knob(KNOB_VAL_TYPE val)
 {
 	if (val < MIN_DRIVE) return MIN_DRIVE;
 	else if (val > MAX_DRIVE) return MAX_DRIVE;
 	else return val;
 }
 
-inline uint8_t prepare_bit_depth_knob(KNOB_VAL_TYPE val)
+uint8_t prepare_bit_depth_knob(KNOB_VAL_TYPE val)
 {
 	if ((uint8_t)val < MIN_BIT_DEPTH) return MIN_BIT_DEPTH;
 	else if ((uint8_t)val > MAX_BIT_DEPTH) return MAX_BIT_DEPTH;
 	else return (uint8_t)val;
 }
 
-inline uint8_t prepare_downsampling_knob(KNOB_VAL_TYPE val)
+uint8_t prepare_downsampling_knob(KNOB_VAL_TYPE val)
 {
 	if ((uint8_t)val < MIN_DOWNSAMPLING) return MIN_DOWNSAMPLING;
 	else if ((uint8_t)val > MAX_DOWNSAMPLING) return MAX_DOWNSAMPLING;
 	else return (uint8_t)val;
 }
 
-inline float prepare_dry_knob(KNOB_VAL_TYPE val)
+float prepare_dry_knob(KNOB_VAL_TYPE val)
 {
 	if (val < MIN_DRY) return MIN_DRY;
 	else if (val > MAX_DRY) return MAX_DRY;
 	else return val;
 }
 
-inline float prepare_wet_knob(KNOB_VAL_TYPE val)
+float prepare_wet_knob(KNOB_VAL_TYPE val)
 {
 	if (val < MIN_WET) return MIN_WET;
 	else if (val > MAX_WET) return MAX_WET;
 	else return val;
 }
 
-inline uint8_t prepare_invert_wet_phase_knob(KNOB_VAL_TYPE val)
+uint8_t prepare_invert_wet_phase_knob(KNOB_VAL_TYPE val)
 {
 	if ((uint8_t)val < MIN_INVERT_WET_PHASE) return MIN_INVERT_WET_PHASE;
 	else if ((uint8_t)val > MAX_INVERT_WET_PHASE) return MAX_INVERT_WET_PHASE;


### PR DESCRIPTION
Proposal of fixing issue #3 
* Fixed segmentation fault (tested with LMMS, issue was NULL copyright set crashing the program)
```
Notice: could not set realtime priority.
VST sync support disabled in your configuration
[1]    2766 segmentation fault (core dumped)  lmms
```

* Fixed undefined symbol errors both in LV2 and LAPSDA plugins (tested with Audacity, removed inline statements since gcc seem to break the export symbols)
```
lilv_lib_open(): error: Failed to open library /usr/lib/lv2/bit-crusher.lv2/bit-crusher.so (/usr/lib/lv2/bit-crusher.lv2/bit-crusher.so: undefined symbol: prepare_downsampling_knob)
```
  